### PR TITLE
allow setting password in redis configuration

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,23 +1,25 @@
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
-    celluloid (0.15.2)
-      timers (~> 1.1.0)
-    connection_pool (2.0.0)
+    celluloid (0.16.0)
+      timers (~> 4.0.0)
+    connection_pool (2.2.0)
     daemons (1.1.9)
+    hitimes (1.2.2)
     json (1.8.1)
     newrelic_plugin (1.3.1)
       json
     redis (3.1.0)
-    redis-namespace (1.5.0)
+    redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
-    sidekiq (3.1.4)
-      celluloid (>= 0.15.2)
-      connection_pool (>= 2.0.0)
+    sidekiq (3.4.1)
+      celluloid (~> 0.16.0)
+      connection_pool (>= 2.1.1)
       json
       redis (>= 3.0.6)
       redis-namespace (>= 1.3.1)
-    timers (1.1.0)
+    timers (4.0.1)
+      hitimes
 
 PLATFORMS
   ruby

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ GEM
     celluloid (0.16.0)
       timers (~> 4.0.0)
     connection_pool (2.2.0)
-    daemons (1.1.9)
+    daemons (1.2.2)
     hitimes (1.2.2)
     json (1.8.1)
     newrelic_plugin (1.3.1)

--- a/config/newrelic_plugin.yml.example
+++ b/config/newrelic_plugin.yml.example
@@ -24,4 +24,5 @@ agents:
     -
       name: 'App name'
       uri: 'redis://localhost:6379'
+      password: 'password'
       namespace: 'namespace'

--- a/newrelic_sidekiq_agent
+++ b/newrelic_sidekiq_agent
@@ -13,7 +13,7 @@ module NewRelic::Sidekiq
 
     agent_guid 'com.eksoverzero.newrelic-sidekiq-agent'
     agent_config_options :name, :uri, :password, :namespace
-    agent_version '1.1.0'
+    agent_version '1.1.1'
     agent_human_labels('Sidekiq') { name }
 
     def setup_metrics

--- a/newrelic_sidekiq_agent
+++ b/newrelic_sidekiq_agent
@@ -12,7 +12,7 @@ module NewRelic::Sidekiq
   class Agent < NewRelic::Plugin::Agent::Base
 
     agent_guid 'com.eksoverzero.newrelic-sidekiq-agent'
-    agent_config_options :name, :uri, :namespace
+    agent_config_options :name, :uri, :password, :namespace
     agent_version '1.1.0'
     agent_human_labels('Sidekiq') { name }
 
@@ -27,7 +27,7 @@ module NewRelic::Sidekiq
       end
 
       Sidekiq.configure_client do |config|
-        config.redis = { url: uri, namespace: namespace }
+        config.redis = { url: uri, password: password, namespace: namespace }
       end
 
       begin


### PR DESCRIPTION
Redis servers can be set up with a password but no username. This is the case for example with Redis Labs, the top redis cloud provider. This pull request adds a password configuration option and passes that through to the Sidekiq Client (which already handles it). Also upgrades the sidekiq gem so that the password does not get logged. 

Other gems bumped are incidental, not required.